### PR TITLE
andorid.cross: add some more default configure options

### DIFF
--- a/prepare/android.cross
+++ b/prepare/android.cross
@@ -26,6 +26,10 @@ sys_root = toolchain / 'sysroot/'
 [host_machine]
 system = 'android'
 
+[libffi:project options]
+doc = false
+tests = false
+
 [glib:built-in options]
 default_library = 'shared'
 
@@ -51,6 +55,9 @@ utilities = 'disabled'
 builtin_loaders = ['all']
 glycin = 'disabled'
 documentation = false
+man = false
+tests = false
+installed_tests = false
 
 [gtk:project options]
 android-backend = true


### PR DESCRIPTION
The new libffi options are only available since glib 2.87.0, so we'll have to wait until gtk bumps its glib wrap