### PR TITLE
fix 'Useless use of a constant (/opt/android-studio/) in void context' warning

### DIFF
--- a/pixiewood
+++ b/pixiewood
@@ -280,7 +280,7 @@ my %actions = (
 	"prepare" => sub {
 		my $meson = "meson";
 
-		my $studio_dir = $ENV{ANDROID_STUDIO_DIR} or "/opt/android-studio/";
+		my $studio_dir = $ENV{ANDROID_STUDIO_DIR} || "/opt/android-studio/";
 		my $sdk = $ENV{ANDROID_HOME};
 		my $toolchain;
 


### PR DESCRIPTION
This fixes the default value and the warning for the sdk location when neither
the env variable nor the command line option is specified.

Sorry for introducing an issue in my first PR 😓.
