### PR TITLE
Svg2Avd: add additional guava name

### DIFF
--- a/generate/Svg2Avd
+++ b/generate/Svg2Avd
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S java --source 11 -cp ${STUDIO_DIR}/lib/lib.jar:${STUDIO_DIR}/lib/util-8.jar:${STUDIO_DIR}/lib/module-intellij.libraries.guava.jar:${STUDIO_DIR}/plugins/android/lib/android-base-common.jar:${STUDIO_DIR}/plugins/android/lib/sdk-common.jar
+#!/usr/bin/env -S java --source 11 -cp ${STUDIO_DIR}/lib/lib.jar:${STUDIO_DIR}/lib/util-8.jar:${STUDIO_DIR}/lib/module-intellij.libraries.guava.jar:${STUDIO_DIR}/lib/intellij.libraries.guava.jar:${STUDIO_DIR}/plugins/android/lib/android-base-common.jar:${STUDIO_DIR}/plugins/android/lib/sdk-common.jar
 
 import com.android.ide.common.vectordrawable.Svg2Vector;
 


### PR DESCRIPTION
I installed android studio using the official tar.gz and the guava lib ended up being named `intellij.libraries.guava.jar` without the `module-` prefix, causing the Svg2Avd script to fail.

This PR adds it alongside the others.